### PR TITLE
Fixing Backbone Backend Model example

### DIFF
--- a/backbone/index.html
+++ b/backbone/index.html
@@ -443,7 +443,7 @@ $('body').append(view.render().$el);</pre></code>
   <h1>The Backbone Backend</h1>
 
 <pre><code class="javascript">var BookModel = Backbone.Model.extend(
-  url: "/api/books",
+  urlRoot: "/api/books",
   // ...
 });
 </pre></code>


### PR DESCRIPTION
Updating Backbone Backend Model example to use 'urlRoot' instead of 'url' to match the intended GET request URL.

Specifying the "url" would result in a GET request to "/api/books", while "urlRoot" creates a GET request to "/api/books/12"
