### PR TITLE
Fixed typo in /index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/ajax/README.md">Meetup description</a>
         <tr>
-           <td><a href="http://gdisf-js-apis.appspot.com/">JS303: Client-side APIs</a>
+           <td><a href="http://teaching-materials.org/">JS303: Client-side APIs</a>
            <td>JS203
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/apis/README.md">Meetup description</a>

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/ajax/README.md">Meetup description</a>
         <tr>
-           <td><a href="http://teaching-materials.org/">JS303: Client-side APIs</a>
+           <td><a href="http://teaching-materials.org/apis/">JS303: Client-side APIs</a>
            <td>JS203
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/apis/README.md">Meetup description</a>


### PR DESCRIPTION
# Summary

Fixes issue #247 typo

Here's a description of changes:

*changed http://gdisf-js-apis-appspot.com/ to http://teaching-materials.org
- ...
- ...

cc @gdisf/admins
http://gdisf-js-apis.appspot.com/ changed to http://teaching-materials.org/
