### PR TITLE
Replace images #143

### DIFF
--- a/git/slides.html
+++ b/git/slides.html
@@ -509,7 +509,7 @@ function addThree(num) {
     <div class="slide normal"> 
      <header><h1>Git Workflow</h1></header> 
      <section class="content"> 
-     <img src="http://thkoch2001.github.com/whygitisbetter/images/local-remote.png">
+     <img src="https://github.com/schacon/whygitisbetter/blob/master/images/local-remote.png">
      </section>
     </div>
     
@@ -688,7 +688,7 @@ HEAD is now at 6853adc... First commit
     <div class="slide normal"> 
      <header><h1>Using branches</h1></header> 
      <section class="content"> 
-     <img src="http://blogs.sitepoint.com/wp-content/uploads/2010/10/branching.jpg" style="float:right">
+     <img src="http://dab1nmslvvntp.cloudfront.net/wp-content/uploads/2010/10/branching.jpg" style="float:right">
 <p>Create the branch:</p>
 <pre>git branch mybranch</pre>
 <p>Switch to the branch:</p>
@@ -724,7 +724,7 @@ HEAD is now at 6853adc... First commit
      <header><h1>Github</h1></header> 
      <section class="content"> 
      
-<img src="https://a248.e.akamai.net/assets.github.com/images/modules/about_page/octocat.png?1306884374" style="float:right;">
+<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/PEO-octocat-1.svg/2000px-PEO-octocat-1.svg.png" style="float:right; width:200px;">
 <ul>
   <li>Hosted, shared git repositories
   <li>Code reviews


### PR DESCRIPTION
# Summary

Fixes issue #143

Here's a description of changes:

* Replaced http://thkoch2001.github.com/whygitisbetter/images/local-remote.png 
to: https://github.com/schacon/whygitisbetter/blob/master/images/local-remote.png
* Replaced: http://www.sitepoint.com/wp-content/uploads/2010/10/branching.jpg
to: http://dab1nmslvvntp.cloudfront.net/wp-content/uploads/2010/10/branching.jpg
* Replaced: https://a248.e.akamai.net/assets.github.com/images/modules/about_page/octocat.png?1306884374
to this CC-BY image of an Octocat (https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/PEO-octocat-1.svg/2000px-PEO-octocat-1.svg.png)

cc @gdisf/admins
replaced the following images to the specified links:
- local-remote.png
- branching.jpg
Also replaced the octocat image to a CC-BY 3.0 image