### PR TITLE
Fixing reference to non existent files and typo

### DIFF
--- a/javascript/index.html
+++ b/javascript/index.html
@@ -86,7 +86,7 @@
 
       <h3>Additional Reading:</h3>
        <ul>
-        <li><a href="http://www.play-hookey.com/computers/language_levels.html">Language Levels</a><li>
+        <li><a href="http://www.play-hookey.com/computers/language_levels.html">Language Levels</a></li>
         <li><a href="http://dailyjs.com/history-of-javascript.html">The History of JavaScript</a></li>
         <li><a href="http://oreilly.com/javascript/excerpts/learning-javascript/javascript-datatypes-variables.html">JavaScript Data Types &amp; Variables</a></li>
         <li><a href="http://www.quirksmode.org/js/function.html">JavaScript Functions</a></li>

--- a/javascript/slides/programming.html
+++ b/javascript/slides/programming.html
@@ -7,9 +7,9 @@
 <link rel="stylesheet" type="text/css" href="../../common/presentation.css" />
 <link rel="stylesheet" type="text/css" href="../../common/prettify.css" />
 <link  href="http://fonts.googleapis.com/css?family=Ubuntu:300,300italic,regular,italic,500,500italic,bold,bolditalic" rel="stylesheet" type="text/css">
-<script src="js/jquery.js" type="text/javascript"></script>
-<script src="js/fathom.js"></script>
-<script src="js/prettify.js"></script>
+<script src="../../common/js/jquery.js" type="text/javascript"></script>
+<script src="../../common/js/fathom.js"></script>
+<script src="../../common/js/prettify.js"></script>
 <script>
 $(document).ready(function(){
     $('pre').addClass('prettyprint').attr('tabIndex', 0);


### PR DESCRIPTION
# Summary

Here's a description of changes:

* Slides were broken because of reference to jquery in local file that was removed. Changed to reference common lib.
* There was a `<li>` tag where it was supposed to be closed.