### PR TITLE
Clarify wording of Grade Assigner for loop exercise (issue #327)

### DIFF
--- a/javascript/exercises/forloops.html
+++ b/javascript/exercises/forloops.html
@@ -58,8 +58,7 @@ for (var multiplier = 0; multiplier &lt;= 10; multiplier++) {
 
 <h3 class="page-header">The Grade Assigner</h3>
 
-<p>Check the results of <code>assignGrade</code> function from the <a href="ifelse.html">conditionals exercise</a> for every value from 60 to 100 -
-so your log should show "For 89, you got a B. For 90, you got an A.", etc.
+<p>Check the results of your <code>assignGrade</code> function from the <a href="ifelse.html">conditionals exercise</a> by logging every value from 60 to 100: your log should show "For 88, you got a B. For 89, you got a B. For 90, you got an A. For 91, you got an A.", etc., logging each grade point in the range.
 </p>
 <button class="btn" onclick="showSolution(3)">See Solution</button>
 <pre id="solution3" style="display:none;">
@@ -83,7 +82,7 @@ for (var i = 80; i &lt;= 100; i++) {
 </pre>
 
   <br><br><br><br><br>
-  
+
  </div>
 
   <script>


### PR DESCRIPTION
# Summary

Fixes issue #327 

Here's a description of changes:

* Added details to instructions for Grade Assigner exercise in For Loops section: clarify that students should be logging something for each grade point (rather than just passing in a score to generate a letter grade, as they did previously in the if/else section)

cc @gdisf/admins
