### PR TITLE
Updates to jsweb slides and exercises

### DIFF
--- a/jsweb/exercises/dom_detective.html
+++ b/jsweb/exercises/dom_detective.html
@@ -12,34 +12,37 @@
   <body>
     <div class="container">
     <h2>Exercise: DOM Detective</h2>
-    <h3 class="page-header">CASE #1: Can She Develop It?</h3>
+    <!-- <h3 class="page-header">CASE #1: Can She Develop It?</h3> -->
     <ul>
-      <li>Navigate to the<a href="http://www.girldevelopit.com">Girl Develop It</a> site,
+      <li>Navigate to the <a href="http://www.girldevelopit.com">Girl Develop It</a> site,
      and open up the Dev Tools console – <code>Cmd</code>-<code>Opt</code>-<code>I</code> (Mac), <code>Ctrl</code>-<code>Shift</code>-<code>I</code> (Windows)
       </li>
       <li>Use the <a href="https://www.khanacademy.org/computing/computer-programming/html-css-js/html-js-dom-access/a/summary-dom-access-methods">DOM access methods</a> we learned to find the following parts of the page. There may be multiple ways to select the same DOM node.</li>
         <ol>
           <li>Every image on the page (as a collection)</li>
-          <li>The navigation area in the upper right</li>
           <li>The MailChimp form at the bottom</li>
+          <li>The three <code>div</code>s with GDI stats (as a collection)</li>
+          <li>The image header with the headline, "DON'T BE SHY DEVELOP IT"</li>
+          <li>The navigation menu at the top</li>
           <li>The GDI logo in the upper-left</li>
-          <li>The media logos (TED, lifehacker, etc.), at the bottom</li>
-          <li>The "DON'T BE SHY DEVELOP IT" headline</li>
+          <li>The media logos (TED, lifehacker, etc.) at the bottom (as a collection)</li>
           <li>All the red dots on the US map (as a collection)</li>
        </ol>
     </ul>
+    <p><strong>Bonus:</strong> Find another element (or collection of elements), and challenge a classmate to find it in the DOM.</p>
     <button onclick="showSolution(1)" class="btn">See Solution</button>
     <br><br>
-    <pre id="solution1" style="display:none;">
-      document.getElementsByTagName("img");
-      document.getElementsByClassName("nav");
-      document.getElementById("mc_embed_signup");
-      document.querySelector(".logo img");
-      document.querySelectorAll(".press-logos img");
-      document.querySelector(".opener h1");
-      document.querySelectorAll("circle");
-    </pre>
-    <h3 class="page-header">CASE #2: Picking Brain Pickings</h3>
+<pre id="solution1" style="display:none;">
+  document.getElementsByTagName("img");
+  document.getElementById("mc_embed_signup");
+  document.getElementsByClassName("stats");
+  document.getElementsByClassName("opener")[0];
+  document.querySelector(".navigation");
+  document.querySelector(".logo img");
+  document.querySelectorAll(".press-logos img");
+  document.querySelectorAll("circle");
+</pre>
+    <!-- <h3 class="page-header">CASE #2: Picking Brain Pickings</h3>
     <ul>
       <li>Open up <a href="http://www.brainpickings.org">brainpickings.com</a> in Chrome or Firefox,
       and open up the console.
@@ -52,7 +55,7 @@
           <li>The "Name" input box for email subscription in the left nav bar</li>
           <li>Every quote insode a blog post</li>
         </ol>
-    </ul>
+    </ul> -->
     <script>
       function showSolution(num) {
         if (confirm('Are you sure?')) {

--- a/jsweb/exercises/dom_manipulation.html
+++ b/jsweb/exercises/dom_manipulation.html
@@ -13,23 +13,27 @@
     <div class="container">
     <h2>Exercise: The Logo Hijack</h2>
     <ul>
-      <li>Navigate to the <a href="http://www.google.com">Google</a> site,
+      <li>Navigate to the <a href="http://www.stanford.edu/">Stanford</a> website,
       and open up the Dev Tools console – Cmd-Opt-I (Mac), Ctrl-Shift-I (Windows)</li>
-      <li>Find the Google logo and store it in a variable.</li>
-      <li>Modify the source of the logo's image so that the image now points to the Yahoo logo instead.</li>
-      <li>Find the Google search button and store it in a variable.</li>
-      <li>Modify the text of the button so that it says "Yahooo!" instead.</li>
+      <li>Find the Stanford logo and store it in a variable.</li>
+      <li>Modify the source of the logo's image so that the image now points to the UC Berkeley logo instead.</li>
+      <li>Find the header and store it in a variable.</li>
+      <li>Change the header background color to 'gold'.</li>
+      <li>Find the 'About Stanford' menu link and store it in a variable.</li>
+      <li>Modify the text of the link so that it says "About Cal" instead.</li>
+      <li>Modify the link so that it points to <a href="http://www.berkeley.edu/about" target="_blank">Cal's About page</a> instead.</li>
     </ul>
     <button onclick="showSolution(1)" class="btn">See Solution</button>
     <br><br>
-    <pre id="solution1" style="display:none;">
-      var img = document.getElementById('hplogo');
-      img.width = 400;
-      img.src = 'http://www.logostage.com/logos/yahoo.GIF';
-      var button = document.getElementById('gbqfba');
-      button.innerHTML = 'Yahoooo!';
-    </pre>
-    <br><br><br><br><br>
+<pre id="solution1" style="display:none;">
+  var logo = document.querySelector('#logo img');
+  img.src = 'http://www.berkeley.edu/images/uploads/logo-ucberkeley.png';
+  var header = document.getElementById('header');
+  header.style.backgroundColor = 'gold';
+  var link = document.querySelector('#nav-about a');
+  link.textContent = 'About Cal';
+  link.href = 'http://www.berkeley.edu/about';
+</pre>
     <script>
       function showSolution(num) {
         if (confirm('Are you sure?')) {

--- a/jsweb/exercises/dom_manipulation_advanced.html
+++ b/jsweb/exercises/dom_manipulation_advanced.html
@@ -14,164 +14,167 @@
       <h2 class="page-header">About Me</h2>
       <ul>
         <li>Start with this HTML and save it as "about_me.html":
-          <pre>
-            &lt;!DOCTYPE html&gt;
-            &lt;html&gt;
-              &lt;head&gt;
-                &lt;meta charset=&quot;utf-8&quot;/&gt;
-                &lt;title&gt;About Me&lt;/title&gt;
-              &lt;/head&gt;
-              &lt;body&gt;
-                &lt;h1&gt;About Me&lt;/h1&gt;
-                
-                &lt;ul&gt;
-                  &lt;li&gt;Nickname: &lt;span id=&quot;nickname&quot;&gt;&lt;/span&gt;
-                  &lt;li&gt;Favorites:  &lt;span id=&quot;favorites&quot;&gt;&lt;/span&gt;
-                  &lt;li&gt;Hometown: &lt;span id=&quot;hometown&quot;&gt;&lt;/span&gt;
-                &lt;/ul&gt;
-              &lt;/body&gt;
-            &lt;/html&gt;
-          </pre>
+<pre>
+  &lt;!DOCTYPE html&gt;
+  &lt;html&gt;
+    &lt;head&gt;
+      &lt;meta charset=&quot;utf-8&quot;/&gt;
+      &lt;title&gt;About Me&lt;/title&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
+      &lt;h1&gt;About Me&lt;/h1&gt;
+      
+      &lt;ul&gt;
+        &lt;li&gt;Nickname: &lt;span id=&quot;nickname&quot;&gt;&lt;/span&gt;
+        &lt;li&gt;Favorites:  &lt;span id=&quot;favorites&quot;&gt;&lt;/span&gt;
+        &lt;li&gt;Hometown: &lt;span id=&quot;hometown&quot;&gt;&lt;/span&gt;
+      &lt;/ul&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+</pre>
         </li>
         <li>Add a <code>script</code> tag to the bottom of the HTML body.</li>
         <li>(In the JavaScript) Change the body tag's style so it has a font-family of "Arial, sans-serif".</li>
         <li>(In the JavaScript) Replace each of the spans (nickname, favorites, hometown) with your own information.</li>
-        <li>Iterate through each li and change the class to "list-item". Add a <code>style</code>
-        tag that sets a rule for "list-item" to make the color red.</li>
+        <li>Iterate through each <code>li</code> and change the class to "list-item".</li>
+        <li>(In the HTML <code>head</code>) Add a <code>style</code> tag that sets a rule for <code>.list-item</code> to make the color red.</li>
         <li>Create a new <code>img</code> element and set its <code>src</code> attribute to
         a picture of you. Append that element to the page.</li>
       </ul>
       <button onclick="showSolution(1)" class="btn">See Solution</button>
       <br><br>
-      <pre id="solution1" style="display:none;">
-        &lt;!DOCTYPE html&gt;
-        &lt;html&gt;
-         &lt;head&gt;
-          &lt;meta charset=&quot;utf-8&quot;/&gt;
-          &lt;title&gt;About Me&lt;/title&gt;
-          &lt;style&gt;
-            .listitem {
-              color: red;
-            }
-          &lt;/style&gt;
-        &lt;/head&gt;
-        &lt;body&gt;
-          &lt;h1&gt;About Me&lt;/h1&gt;
-          
-          &lt;ul&gt;
-            &lt;li&gt;Nickname: &lt;span id=&quot;nickname&quot;&gt;&lt;/span&gt;
-            &lt;li&gt;Favorites:  &lt;span id=&quot;favorites&quot;&gt;&lt;/span&gt;
-            &lt;li&gt;Hometown: &lt;span id=&quot;hometown&quot;&gt;&lt;/span&gt;
-           &lt;/ul&gt;
-          
-          &lt;script&gt;
-           document.body.style.fontFamily = 'Arial, sans-serif';
-           document.getElementById('nickname').innerHTML = 'Pamela Fox';
-           document.getElementById('favorites').innerHTML = '27';
-           document.getElementById('hometown').innerHTML = 'Pasadena, CA';
-           var items = document.getElementsByTagName('li');
-           for (var i = 0; i &lt; items.length; i++) {
-              items[i].className = 'listitem';
-           }
-            
-            var myPic = document.createElement('img');
-            myPic.src = 'http://gotocon.com/dl/jaoo_aus2008/photos/speakers/Pamela_Fox.jpg';
-            document.body.appendChild(myPic);
-          &lt;/script&gt;
-        &lt;/body&gt;
-        &lt;/html&gt;
-      </pre>
+<pre id="solution1" style="display:none;">
+  &lt;!DOCTYPE html&gt;
+  &lt;html&gt;
+   &lt;head&gt;
+    &lt;meta charset=&quot;utf-8&quot;/&gt;
+    &lt;title&gt;About Me&lt;/title&gt;
+    &lt;style&gt;
+      .list-item {
+        color: red;
+      }
+    &lt;/style&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;h1&gt;About Me&lt;/h1&gt;
+    
+    &lt;ul&gt;
+      &lt;li&gt;Nickname: &lt;span id=&quot;nickname&quot;&gt;&lt;/span&gt;
+      &lt;li&gt;Favorites:  &lt;span id=&quot;favorites&quot;&gt;&lt;/span&gt;
+      &lt;li&gt;Hometown: &lt;span id=&quot;hometown&quot;&gt;&lt;/span&gt;
+     &lt;/ul&gt;
+    
+    &lt;script&gt;
+     document.body.style.fontFamily = 'Arial, sans-serif';
+     document.getElementById('nickname').textContent = 'Princess Bubblegum';
+     document.getElementById('favorites').textContent = 'science, music, my candy subjects';
+     document.getElementById('hometown').textContent = 'Candy Kingdom';
+     var items = document.getElementsByTagName('li');
+     for (var i = 0; i &lt; items.length; i++) {
+        items[i].className = 'list-item';
+     }
+      
+      var myPic = document.createElement('img');
+      myPic.src = 'https://upload.wikimedia.org/wikipedia/en/thumb/0/00/Princess_Bubblegum.png/100px-Princess_Bubblegum.png';
+      document.body.appendChild(myPic);
+    &lt;/script&gt;
+  &lt;/body&gt;
+  &lt;/html&gt;
+</pre>
 
       <h2 class="page-header">The Book List</h2>
       <ul>
-        <li>Create a webpage with an <code>h1</code> of "My Book List".
-        <li>Add a script tag to the bottom of the page, where all your JS will go.
+        <li>Create a webpage with an <code>h1</code> of "My Book List".</li>
+        <li>Add a <code>script</code> tag to the bottom of the page, where all your JS will go.</li>
         <li>Copy this array of books:
-        <pre>
-          var books = [
-            {
-              title: 'The Design of EveryDay Things',
-              author: 'Don Norman',
-              alreadyRead: false
-            }, {
-              title: 'The Most Human Human',
-              author: 'Brian Christian',
-              alreadyRead: true
-            }
-          ];
-        </pre>
+<pre>
+  var books = [
+    {
+      title: 'The Design of EveryDay Things',
+      author: 'Don Norman',
+      alreadyRead: false
+    }, {
+      title: 'The Most Human Human',
+      author: 'Brian Christian',
+      alreadyRead: true
+    }
+  ];
+</pre></li>
         <li>Iterate through the array of books. For each book, create a <code>p</code>
-        element with the book title and author and append it to the page.
-        <li>Use a <code>ul</code> and <code>li</code> to display the books.
-        <li><b>Bonus</b>: Add an <code>img</code> to each book that links to a URL of the book cover.
-        <li><b>Bonus</b>: Change the style of the book depending on whether you have read it or not.
+        element with the book title and author and append it to the page.</li>
+        <li><strong>Bonuses:</strong>
+          <ul>
+            <li>Use a <code>ul</code> and <code>li</code> to display the books.</li>
+            <li>Add an <code>img</code> to each book that links to a URL of the book cover.</li>
+            <li>Change the style of the book depending on whether you have read it or not.</li>
+          </ul>
+        </li>
       </ul>
       <button onclick="showSolution(2)" class="btn">See Solution</button>
       <br><br>
-      <pre id="solution2" style="display:none;">
-        &lt;!DOCTYPE html&gt;
-        &lt;html&gt;
-         &lt;head&gt;
-          &lt;meta charset=&quot;utf-8&quot;/&gt;
-          &lt;title&gt;Book List&lt;/title&gt;
-         &lt;/head&gt;
-        &lt;body&gt;
+<pre id="solution2" style="display:none;">
+  &lt;!DOCTYPE html&gt;
+  &lt;html&gt;
+   &lt;head&gt;
+    &lt;meta charset=&quot;utf-8&quot;/&gt;
+    &lt;title&gt;Book List&lt;/title&gt;
+   &lt;/head&gt;
+  &lt;body&gt;
 
-        &lt;h1&gt;My Book List&lt;/h1&gt;
-        &lt;script&gt;
-        var books = [
-          {title: 'The Design of EveryDay Things',
-           author: 'Don Norman',
-           alreadyRead: false
-          },
-          {title: 'The Most Human Human',
-           author: 'Brian Christian',
-           alreadyRead: true
-          }];
-            
-        for (var i = 0; i &lt; books.length; i++) {
-          var bookP = document.createElement('p');
-          var bookDescription = document.createTextNode(books[i].title + ' by ' + books[i].author);
-          bookP.appendChild(bookDescription);
-          document.body.appendChild(bookP);
-        }
+  &lt;h1&gt;My Book List&lt;/h1&gt;
+  &lt;script&gt;
+  var books = [
+    {title: 'The Design of EveryDay Things',
+     author: 'Don Norman',
+     alreadyRead: false
+    },
+    {title: 'The Most Human Human',
+     author: 'Brian Christian',
+     alreadyRead: true
+    }];
+      
+  for (var i = 0; i &lt; books.length; i++) {
+    var bookP = document.createElement('p');
+    var bookDescription = document.createTextNode(books[i].title + ' by ' + books[i].author);
+    bookP.appendChild(bookDescription);
+    document.body.appendChild(bookP);
+  }
 
 
 
-        // OR, with the bonuses:
-        var books = [
-          {title: 'The Design of EveryDay Things',
-           img: 'http://ecx.images-amazon.com/images/I/41j2ODGkJDL._AA115_.jpg',
-           author: 'Don Norman',
-           alreadyRead: false
-          },
-          {title: 'The Most Human Human',
-           img: 'http://ecx.images-amazon.com/images/I/41Z56GwEv9L._AA115_.jpg',
-           author: 'Brian Christian',
-           alreadyRead: true
-          }];
-            
-        var bookList = document.createElement('ul');
-        for (var i = 0; i &lt; books.length; i++) {
-          var bookItem = document.createElement('li');
-          var bookImg = document.createElement('img');
-          bookImg.src = books[i].img;
-          bookItem.appendChild(bookImg);
-          var bookDescription = document.createTextNode(books[i].title + ' by ' + books[i].author);
-          bookItem.appendChild(bookDescription);
-          if (books[i].alreadyRead) {
-            bookItem.style.color = 'grey';
-          }
-          bookList.appendChild(bookItem);
-        }
-        document.body.appendChild(bookList);
-        &lt;/script&gt;
-          
-        &lt;/body&gt;
-        &lt;/html&gt;
-      </pre>
+  // OR, with the bonuses:
+  var books = [
+    {title: 'The Design of EveryDay Things',
+     img: 'http://ecx.images-amazon.com/images/I/41j2ODGkJDL._AA115_.jpg',
+     author: 'Don Norman',
+     alreadyRead: false
+    },
+    {title: 'The Most Human Human',
+     img: 'http://ecx.images-amazon.com/images/I/41Z56GwEv9L._AA115_.jpg',
+     author: 'Brian Christian',
+     alreadyRead: true
+    }];
+      
+  var bookList = document.createElement('ul');
+  for (var i = 0; i &lt; books.length; i++) {
+    var bookItem = document.createElement('li');
+    var bookImg = document.createElement('img');
+    bookImg.src = books[i].img;
+    bookItem.appendChild(bookImg);
+    var bookDescription = document.createTextNode(books[i].title + ' by ' + books[i].author);
+    bookItem.appendChild(bookDescription);
+    if (books[i].alreadyRead) {
+      bookItem.style.color = 'grey';
+    }
+    bookList.appendChild(bookItem);
+  }
+  document.body.appendChild(bookList);
+  &lt;/script&gt;
+    
+  &lt;/body&gt;
+  &lt;/html&gt;
+</pre>
     </div>
-    <br><br><br><br><br>
     <script>
       function showSolution(num) {
         if (confirm('Are you sure?')) {

--- a/jsweb/slides/animevents.html
+++ b/jsweb/slides/animevents.html
@@ -382,11 +382,13 @@ jQuery("#start-button").click(onClick);
  <li>Conferences (<a href="http://events.jquery.org/2012/sf/">jQuery Con</a>, <a href="http://2012.jsconf.us/">JSConf</a>, <a href="http://fluentconf.com/fluent2012">Fluent</a>, ...)
 </ul>
      </section>
-
-
-
-
-
+		 
+     <section>
+      <h2>Questions?</h2> 
+      
+      <p><a href="../index.html">Return to Table of Contents</a></p>
+      
+     </section>
    
 			</div>
   		<footer>

--- a/jsweb/slides/dom.html
+++ b/jsweb/slides/dom.html
@@ -315,6 +315,14 @@ body.appendChild(newParagraph);
       </a>
     </h2>
     </section>
+		
+     <section>
+      <h2>Questions?</h2> 
+      
+      <p><a href="../index.html">Return to Table of Contents</a></p>
+      
+     </section>
+
 
 			</div>
   		<footer>

--- a/jsweb/slides/dom.html
+++ b/jsweb/slides/dom.html
@@ -25,6 +25,8 @@
 				border: 2px dashed #01a9b4;
 			}
 		</style>
+		
+		<base target="_blank">
 
 		<!-- If use the PDF print sheet so students can print slides-->
 
@@ -56,9 +58,10 @@
       <h2>Text Editors</h2>
         <p>Many text editors provide special assistance for writing HTML and CSS, like syntax-highlighting and autocompletion.</p>
         <ul>
-          <li>Sublime Text, TextMate (Mac)</li>
-          <li>Notepad++ (Windows)</li>
-          <li>JSBin, JSFiddle (Online)</li>
+          <li>Sublime Text, Atom (Mac, Windows, Linux)</li>
+					<li>TextMate (Mac only)</li>
+          <li>Notepad++ (Windows only)</li>
+          <li>JSBin, JSFiddle, Codepen, Cloud9 (Online)</li>
         </ul>
 <pre><code class="html xml">&lt;h1&gt;My JavaScript questions&lt;/h1&gt;
 &lt;ul&gt;
@@ -112,12 +115,15 @@
           </li>
           <li><a href="http://msdn.microsoft.com/en-us/library/dd565628%28VS.85%29.aspx#html_elementinfo">Internet Explorer</a>
             <ul>
-              <li>Open Tools, "Developer Tools"</li>
+              <li>Open Tools > "Developer Tools"</li>
             </ul>
           </li>
+					<li><a href="https://developer.apple.com/library/content/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/GettingStarted/GettingStarted.html">Safari</a>
+						<ul>
+							<li>Unlock the Develop Menu by opening Safari > Preferences > Advanced, and checking the box, "Show Develop menu in menu bar."</li>
+							<li>Access by same methods as Chrome (above)</li>
           </li>
         </ul>
-        <img src="../images/screenshot_chromedevtools.png" style="display: block; margin: auto; width: 535px; border:1px solid black;">
       
     </section>
     <section>
@@ -193,7 +199,7 @@ var againAlsoHobbies = document.querySelectorAll('ul li.hobby');
 var firstHobby = document.querySelector('ul li.hobby');
 </code></pre>
         <br>
-        <p><code>getElementsByClassName()</code>, <code>getElementsByTagName()</code>, and <code>querySelectorAll()</code> return a collection of elements in an array:</p>
+        <p><code>getElementsByClassName()</code>, <code>getElementsByTagName()</code>, and <code>querySelectorAll()</code> return a collection of elements (which acts like an array):</p>
 <pre><code class="javascript">var catNames = document.querySelectorAll('ul li.catname');
 var firstCatName = catNames[0];
 </code></pre>
@@ -211,12 +217,12 @@ var firstCatName = catNames[0];
 <pre><code class="html xml">&lt;img id="lizzie-the-cat" src="http://placekitten.com/200/300"&gt;
 </code></pre>
         <p>Changing the <code>src</code> of an image:</p>
-<pre><code class="javascript">var catImage = document.getElementById('lizzie-the-cat');
+<pre><code class="javascript">var catImage = document.getElementById('lizzie');
 var oldImageSource = catImage.src;
-oldImageSource.src = 'http://placekitten.com/100/500';
+catImage.src = 'http://placekitten.com/300/200';
 </code></pre>
         <p>Changing the <code>className</code> of a DOM node:</p>
-<pre><code class="javascript">var catImage = document.getElementById('lizzie-the-cat');
+<pre><code class="javascript">var catImage = document.getElementById('lizzie');
 catImage.className = "portrait";
 </code></pre>
       
@@ -232,7 +238,7 @@ catImage.className = "portrait";
 }
 </code></pre>
         <p>Applying the Same Styles via JavaScript:</p>
-<pre><code class="javascript">var pageNode = document.getElementsByTagName('body')[0];
+<pre><code class="javascript">var pageNode = document.body;
 pageNode.style.color = 'red';
 pageNode.style.backgroundColor = 'pink';
 pageNode.style.paddingTop = '10px';
@@ -241,7 +247,7 @@ pageNode.style.paddingTop = '10px';
     <section>
       <h2>Manipulating a DOM Node's Inner HTML</h2>
         <p>Each DOM node has an <code>innerHTML</code> attribute that contains the HTML of all its children:</p>
-<pre><code class="javascript">var pageNode = document.getElementsByTagName('body')[0];
+<pre><code class="javascript">var pageNode = document.body;
 console.log(pageNode.innerHTML);
 </code></pre>
         <p>You can set <code>innerHTML</code> yourself to replace the contents of the node:</p>
@@ -250,6 +256,28 @@ console.log(pageNode.innerHTML);
         <p>You can also just add to the <code>innerHTML</code>, instead of replacing it altogether:</p>
 <pre><code class="javascript">pageNode.innerHTML += "P.S. Please do write back.";
 </code></pre>
+      </section>
+
+    <section>
+      <h2><code>innerHTML</code> vs. <code>textContent</code></h2>
+        <p>If you're only changing the actual text of a node, <a href="https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent" target="_blank"><code>textContent</code></a> may be a better choice.</p>
+				<ul>
+					<li><code>innerHTML</code>
+						<ul>
+							<li>Works in older browsers</li>
+							<li>More powerful: can change code</li>
+							<li>Less secure: allows cross-site scripting (XSS)</li>
+						</ul>
+					</li>
+					<li><code>textContent</code>
+						<ul>
+							<li>Doesn't work in IE8 and below</li>
+							<li>Faster: the browser doesn't have to parse HTML</li>
+							<li>More secure: won't execute code</li>
+						</ul>
+					</li>
+				</ul>
+
       </section>
     
     <section>
@@ -266,7 +294,7 @@ document.createTextNode(text);
 document.appendChild(childToAppend);
 </code></pre>
         <img src="../images/dommodify_imgtobody.png" style="float:right; width: 130px; margin-left: 6px; margin-top: 6px;">
-<pre><code class="javascript">var body = document.getElementsByTagName('body')[0];
+<pre><code class="javascript">var body = document.body;
 var newImg = document.createElement('img');
 newImg.src = 'http://placekitten.com/400/300';
 newImg.style.border = '1px solid black';
@@ -281,7 +309,7 @@ body.appendChild(newParagraph);
       
     </section>
     <section>
-     <h1 class="center">
+     <h2 class="center">
       <a target="_blank" href="../exercises/dom_manipulation_advanced.html">
         Master of (DOM) Manipulation Exercise
       </a>

--- a/jsweb/slides/review.html
+++ b/jsweb/slides/review.html
@@ -154,6 +154,14 @@ for (var i = 0; i < children.length; i++) {
     } 
 };</code></pre>
                 </section>
+     <section>
+      <h2>Questions?</h2> 
+      
+      <p><a href="../index.html">Return to Table of Contents</a></p>
+      
+     </section>
+
+
 			</div>
   		<footer>
             <div class="copyright">

--- a/jsweb/slides/welcome.html
+++ b/jsweb/slides/welcome.html
@@ -121,6 +121,14 @@
     </ul>
 
   </section>
+
+     <section>
+      <h2>Questions?</h2> 
+      
+      <p><a href="../index.html">Return to Table of Contents</a></p>
+      
+     </section>
+
 			</div>
   		<footer>
         <div class="copyright">


### PR DESCRIPTION
Minor edits in preparation for upcoming workshop.

Here's a description of changes:

* Add `<base target="_blank">`  to dom.html for easier link clicking (Reveal changes slides if you right click.)
* Add link to contents to the end of each slide deck
* Fix code block indentation in exercises
* Alter DOM detective exercise to match code changes on GDI site, add interactive bonus, remove Brain Pickings exercise (lacked solution code, repetitive)
* Alter Logo Hijack exercise to use Stanford/Cal because current Google/Yahoo pages now have more difficult DOM access
* Add Safari dev tools instructions
* Update text editor options to include Atom, Codepen, Cloud9
* Changes references to `document.getElementsByTagName('body')[0]` to `document.body`
* Alter DOM manipulation sample so that it works with existing JSBin
* Add slide comparing `innerHTML` and `textContent` and changed exercise solutions to use `textContent`
* Minor wording/format changes


cc @gdisf/admins