### PR TITLE
#331 remove useCapture and add link to MDN in addEventListener section

### DIFF
--- a/jsweb/slides/animevents.html
+++ b/jsweb/slides/animevents.html
@@ -61,8 +61,8 @@
     
      <section> 
      <h2>Adding Event Listeners</h2> 
-     <p>In IE 9+ (and all other browsers):</p>
-<pre><code class="javascript syntax">domNode.addEventListener(eventType, eventListener, useCapture);
+     <p><a href='https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener'>In IE 9+ (and all other browsers):</a></p>
+<pre><code class="javascript syntax">domNode.addEventListener(eventType, eventListener);
 </code></pre>
 
 <pre><code class="html xml">&lt;button id=&quot;counter&quot;&gt;0&lt;/button&gt;


### PR DESCRIPTION
# Summary

Fixes issue #.331

Here's a description of changes:

In jsweb/animevents.html
* Remove useCapture argument 
* Add MDN .addEventListener doc in the Adding Event Lister section(page 2)



cc @gdisf/admins
