### PR TITLE
change 'location' argument to 'geoLocation'

### DIFF
--- a/javascript/exercises/functions.html
+++ b/javascript/exercises/functions.html
@@ -29,8 +29,8 @@ so you may start from those (your solutions or ours) or start from scratch.
 <button class="btn" onclick="showSolution(1)">See Solution</button>
 <br><br>
 <pre id="solution1" style="display:none;">
-function tellFortune(jobTitle, location, partner, numKids) {
-    var future = 'You will be a ' + jobTitle + ' in ' + location + ' and married to ' +
+function tellFortune(jobTitle, geoLocation, partner, numKids) {
+    var future = 'You will be a ' + jobTitle + ' in ' + geoLocation + ' and married to ' +
    partner + ' ' + ' with ' + numKids + ' kids.';
     console.log(future);
 }


### PR DESCRIPTION
# Summary

Fixes issue (I saw in class)

Here's a description of changes:
I changed the argument from `location` to `geoLocation`, as `location` should not be used as a variable name. 


cc @gdisf/admins