### PR TITLE
Fixes issue 409, adding follow_up.md to the lesson folder and linking it on teaching-materials/index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
            <td><a href="/jquery/">JS301a: jQuery Intro</a>
            <td>JS200
            <td>2-3hrs
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jquery/README.md">Meetup description</a>
+           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jquery/README.md">Meetup description</a> | Lesson plan</a> | <a href="https://github.com/gdisf/teaching-materials/blob/master/jquery/follow_up.md">Follow Up Email</a>
           <tr>
            <td><a href="/jquery2/">JS301b: More jQuery</a>
            <td>JS301a

--- a/jquery/follow_up.md
+++ b/jquery/follow_up.md
@@ -1,0 +1,23 @@
+# Follow up
+
+Thanks for attending the workshop, and thank you to our TAs [TODO: TA names] for being such great helpers. We’d love your feedback on the workshop in this survey. [TODO: Add link to survey]
+
+The slides are available at:
+[http://teaching-materials.org/jquery/](http://teaching-materials.org/jquery1)
+[http://teaching-materials.org/jquery2/](http://teaching-materials.org/jquery2)
+We will keep them available at that URL.
+
+We both reviewed and covered a lot during the workshop, and for those of you who learnt the JavaScript DOM model recently, you're probably feeling overwhelmed by the amount of information in your head. Just know that it's really impressive how much knowledge you've exposed yourself, and don't worry if it all seems a little crazy. It is! :-)
+
+As usual, the important thing now is to keep practicing what you’ve learnt, at home or at the study groups.
+
+You can also continue learning jQuery via these online resources:
+- [jQFundamentals](http://jqfundamentals.com/)
+- [jQuery](http://www.codecademy.com/tracks/jquery)
+ -[15 jQuery Resources](http://net.tutsplus.com/tutorials/javascript-ajax/15-resources-to-get-you-started-with-jquery-from-scratch/)
+
+The upcoming AJAX workshop [TODO: add meetup url] will show you how to pull data into your site, using either native DOM API or jQuery.
+
+Hope to see you at future [meetups](meetup.com/Girl-Develop-It-San-Francisco/)!
+
+Stay in touch through [Facebook](https://www.facebook.com/gdisf/), [Twitter](https://twitter.com/gdisf), and [Slack](http://gdisf.slack.com). (Not a member? [Sign up for GDI SF Slack here](http://gdisf-slack.herokuapp.com)). Hope to see you at future workshops!


### PR DESCRIPTION
# Summary

Fixes issue #409, adding follow_up.md to the lesson folder and linking it on teaching-materials/index.html

Here's a description of changes:

* adds follow_up.md
* links follow_up.md on /index.html

_Before you merge, make sure you visually check your changes in the deploy preview. A link to the preview will appear in the PR comments when ready._


cc @gdisf/admins
