### PR TITLE
Fix small typo s/an/and/

### DIFF
--- a/css3-selectors/files/02_uiselectors.html
+++ b/css3-selectors/files/02_uiselectors.html
@@ -47,8 +47,8 @@ input:out-of-range { background-color: pink;}
   <input type="text" pattern="[0-9]*" id="testAny"> <label for="testAny">Any digit</label>
 </li>
 <li>
-  <input type="number" min="5" max="7" id="test3ck" required/> 
-  <label  for="test3ck">Number between 5 an 7</label>
+  <input type="number" min="5" max="7" id="test3ck" required/>
+  <label  for="test3ck">Number between 5 and 7</label>
 </li>
 <li><input type="date" id="test4ck" /> <label  for="test4ck">Any date</label></li>
 </ol>

--- a/css3-selectors/files/03_root.html
+++ b/css3-selectors/files/03_root.html
@@ -33,8 +33,8 @@ input:in-range { background-color:lightgreen;}
   <input type="checkbox" id="test2ck"/> <label  for="test2ck">Check and uncheck me too!</label>
   </li>
 <li>
-  <input type="number" min="5" max="7" id="test3ck" required/> 
-  <label  for="test3ck">Number between 5 an 7</label>
+  <input type="number" min="5" max="7" id="test3ck" required/>
+  <label  for="test3ck">Number between 5 and 7</label>
 </li>
 <li><input type="color" pattern="#[a-fA-F0-9]{6}" id="test4ck" /> <label  for="test4ck">Hexidecimal color</label></li>
 </ol>


### PR DESCRIPTION
# Summary

Here's a description of changes:
* Fixes a small typo in the CSS3 selector slides (replace "an" with "and")

cc @gdisf/admins
