### PR TITLE
Remove single colon pseudo-elements for clarity

### DIFF
--- a/css3-selectors/index.html
+++ b/css3-selectors/index.html
@@ -106,14 +106,10 @@ a[target="play"]:after {
   <li>E[attribute|=value]</li>
   <li>:first-child</li>
   <li>:lang()</li>
-  <li>:before</li>
   <li>::before</li>
   <li>::selection</li>
-  <li>:after</li>
   <li>::after</li>
-  <li>:first-letter</li>
   <li>::first-letter</li>
-  <li>:first-line</li>
   <li>::first-line</li>
   <li>E[attribute^=value]</li>
   <li>E[attribute$=value]</li>


### PR DESCRIPTION
# Summary

During the 2017-08-22 session of CSS3 selectors, there was some confusion in the beginning of the class due to there being examples of both `:` and `::` syntax for pseudo-*elements*. Since the spec and [best practice for modern browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#Syntax) say to use the double colon syntax, one way to remove confusion is to just remove the backwards-compatible single colon `:` syntax.

Here's a description of changes:
* In the intro slides recapping selectors, remove instances of pseudo-*elements* using the single colon `:` syntax.

_Before you merge, make sure you visually check your changes in the deploy preview. A link to the preview will appear in the PR comments when ready._


cc @gdisf/admins
