### PR TITLE
[accessibility] #419 Follow-up email in the Accessibility lesson and link in index

### DIFF
--- a/accessibility/follow_up.md
+++ b/accessibility/follow_up.md
@@ -1,0 +1,15 @@
+Thanks for attending the workshop, and thank you to our TAs [TODO: add names here] for being such great helpers. If you haven't filled it out already, we’d love your feedback on the lecture and suggestions for improvement in this brief survey.  [TODO: add link to survey]
+
+The slides are available at: 
+[URL to slides]
+We will always keep them available at that URL. 
+
+The key concepts we discussed were: 
+[CONCEPTS here]
+
+[Other resources that can help students or relevant meetups/events]
+
+We encourage you to keep learning! 
+[Plug to upcoming GDI workshops that apply]
+
+Stay in touch through Facebook, Twitter, Slack. (Not a member? Sign up for GDI SF Slack here). Hope to see you at future workshops!

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         <tr><td><a href="/accessibility/">Web Accessibility Workshop</a>
             <td>None
             <td>3hrs
-            <td>
+            <td>| <a href="https://github.com/gdisf/teaching-materials/blob/accessibility/follow_up.md">Follow Up Email</a>
         <tr><td><a href="/htmlcss-2day/">HTML &amp; CSS (New, Project-Based)</a>
             <td>None
             <td>12hrs

--- a/javascript/marketing.md
+++ b/javascript/marketing.md
@@ -1,0 +1,19 @@
+## One Paragraph Announcement
+
+:tada: * JS101: Intro to JavaScript
+* :tada:
+:calendar: Calendar Day, Month
+:clock6: XX AM - XX PM @ Venue
+
+JavaScript is the programming language that makes web pages interactive. It is also used to make servers, robots, and more! That makes it one of the most useful first languages to learn.
+Prerequisites: Basic HTML & CSS
+
+We also have scholarships available.
+
+*Sign up here:* [TODO: add link to meetup]
+
+## Example Tweets
+- Join us for our #Javascript workshops and learn how to make your website more interactive!  [LINK to meetup]
+- New to web development ? Come to our 2-Day Intro to JavaScript this weekend where you'll learn the fundamentals of programming in #JavaScript [LINK to meetup]
+- Ready to learn JavaScript? @gdisf has a weekend workshop. No programming experience necessary! [LINK to meetup]
+- Open spots for Intro to JavaScript (2 days) with @gdisf [LINK to meetup]


### PR DESCRIPTION
# Summary

Fixes issue #419

Here's a description of changes:

* Created follow_up.md within teaching-materials/accessibility.
* Added link to accessibility follow-up email in /index.html

_Before you merge, make sure you visually check your changes in the deploy preview. A link to the preview will appear in the PR comments when ready._


cc @gdisf/admins
