### PR TITLE
Remove CNAME (no longer using GitHub Pages)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.teaching-materials.org


### PR DESCRIPTION
# Summary

Here's a description of changes:

The CNAME file is a convention used by GitHub to determine domain routing for GitHub Pages. Now that we are no longer using GH Pages, the file is not necessary (and actually generates annoying warning emails from GitHub).