### PR TITLE
[algorithms] fixes code css styles

### DIFF
--- a/algorithms/css/algorithms.css
+++ b/algorithms/css/algorithms.css
@@ -1,3 +1,35 @@
 td, th {
 	text-align: center !important;
 }
+
+.reveal pre {
+    display: block;
+    position: relative;
+    width: 90%;
+    margin: 15px auto;
+    text-align: left;
+    font-size: 0.55em;
+    font-family: monospace;
+    line-height: 1.2em;
+    word-wrap: break-word;
+    box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.3);
+}
+
+.reveal pre code {
+	padding: 5px;
+	overflow: auto;
+	max-height: 400px;
+	word-wrap: normal;
+  text-align: left;
+}
+
+.reveal code {
+    font-family: monospace;
+}
+
+pre code {
+    display: block;
+    background: white;
+    color: #4d4d4c;
+    padding: 0.5em;
+}


### PR DESCRIPTION
# Summary
I'm not sure what previous changes affected the css for code formatting in this slide deck. I pulled the css from an old branch I had.

Fixes issue #538 #537 

Here's a description of changes:
Currently:
![image](https://user-images.githubusercontent.com/7111756/31819825-539fdfb8-b553-11e7-8eaa-869ff94a26ba.png)

After the css additions:
![image](https://user-images.githubusercontent.com/7111756/31819834-5ec87184-b553-11e7-8696-52454b9c60ee.png)

cc @gdisf/admins
