### PR TITLE
[algorithms]fixes css whitespace issue + table margins + super/sub

### DIFF
--- a/algorithms/css/algorithms.css
+++ b/algorithms/css/algorithms.css
@@ -16,11 +16,11 @@ td, th {
 }
 
 .reveal pre code {
-	padding: 5px;
-	overflow: auto;
-	max-height: 400px;
-	word-wrap: normal;
-  text-align: left;
+    padding: 5px;
+    overflow: auto;
+    max-height: 400px;
+    word-wrap: normal;
+    text-align: left;
 }
 
 .reveal code {
@@ -32,4 +32,14 @@ pre code {
     background: white;
     color: #4d4d4c;
     padding: 0.5em;
+}
+
+.reveal sub {
+    vertical-align: sub;
+    font-size: smaller;
+}
+
+.reveal sup {
+    vertical-align: super;
+    font-size: smaller;
 }

--- a/algorithms/index.html
+++ b/algorithms/index.html
@@ -549,8 +549,8 @@ for shirt in shirts_pile:
 
             <section>
               <h2>Time Complexity</h2>
-              <pre><table style="margin:auto; background:white; padding: 5px; font-size:smaller;">
-                <thead>
+              <pre><table style="margin:auto; background:white; padding: 5px; font-size:smaller; width: 100%">
+                <thead style="font-weight: bold;">
                     <tr>
                         <th>Order of growth</th>
                         <th>Name</th>


### PR DESCRIPTION
# Summary
Fixes whitespace issues in `algorithms.css`, weird margins on slide 39, and the super/sub html styling.

Fixes issue #547

Here's a description of changes:
sub styling before:
![image](https://user-images.githubusercontent.com/7111756/31853150-dcce0572-b638-11e7-90f4-6a5f1e34406b.png)
sub styling after:
![image](https://user-images.githubusercontent.com/7111756/31853153-e3f55fe4-b638-11e7-831d-f3e14c4c7f7e.png)

super styling before:
![image](https://user-images.githubusercontent.com/7111756/31853156-f295b198-b638-11e7-9e47-2746b1297db9.png)

super styling after:
![image](https://user-images.githubusercontent.com/7111756/31853159-fbac51a6-b638-11e7-88db-6aa7eb80ee6e.png)

table styling before:
![image](https://user-images.githubusercontent.com/7111756/31853170-2bac784a-b639-11e7-9272-abab069b6160.png)

table styling after:
![image](https://user-images.githubusercontent.com/7111756/31853165-1574ddba-b639-11e7-8d16-f3477aaf9a7e.png)

cc @gdisf/admins
