### PR TITLE
remove outdated materials from index.html, keep in repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,18 +44,6 @@
             <td>None
             <td>12hrs
             <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/htmlcss-2day/README.md">Meetup description</a>
-        <tr><td><a href="/htmlcss-1day/">HTML &amp; CSS (Old, Exercise-Based)</a>
-            <td>None
-            <td>12hrs
-            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/htmlcss-1day/README.md">Meetup description</a>
-             | <a href="https://github.com/gdisf/teaching-materials/blob/htmlcss-1day/follow_up.md">Follow Up Email</a>
-        <tr>
-         <td><a href="htmlcss-selfpaced/">HTML &amp; CSS (Online, Self-paced)</a>
-            <td>None
-            <td>10hrs
-            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/htmlcss-selfpaced/README.md">Meetup description</a>
-              | <a href="htmlcss-selfpaced/lessonplan.html">Lesson plan</a>
-              | <a href="https://github.com/gdisf/teaching-materials/blob/master/htmlcss-selfpaced/follow_up.md">Follow Up Email</a>
         <tr><td><a href="/css3-selectors">CSS3 Selectors</a>
             <td>HTML101
             <td>2-3hrs
@@ -87,36 +75,12 @@
             | Lesson plan</a>
             | <a href="https://github.com/gdisf/teaching-materials/blob/master/javascript/follow_up.md">Follow Up Email</a>
         <tr>
-           <td><a href="/javascript-selfpaced/">JS101: Intro to JavaScript (Online, Self-paced)</a>
-           <td>None
-           <td>10-15hrs
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/javascript-selfpaced/README.md">Meetup description</a>
-            | <a href="javascript-selfpaced/lessonplan.html">Lesson plan</a>
-            | <a href="https://github.com/gdisf/teaching-materials/blob/master/javascript-selfpaced/follow_up.md">Follow Up Email</a>
-        <tr>
-           <td><a href="/jsreview/">JS102: JS Arrays, Objects, Functions</a>
-           <td>JS101
-           <td>6hours
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jsreview/README.md">Meetup description</a>
-           | <a href="https://github.com/gdisf/teaching-materials/blob/master/jsreview/follow_up.md">Follow Up Email</a>
-        <tr>
            <td><a href="/jsweb/">JS200: JS and the Web</a>
            <td>JS101
            <td>5hours
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jsweb/README.md">Meetup description</a>
            | <a href="https://github.com/gdisf/teaching-materials/blob/master/jsweb/follow_up.md">Follow Up Email</a>
-        <tr>
-           <td><a href="jsweb-selfpaced/">JS200: JS and the Web (Online, Self-paced)</a>
-           <td>JS101
-           <td>5hours
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jsweb-selfpaced/README.md">Meetup description</a>
-            | <a href="jsweb-selfpaced/lessonplan.html">Lesson plan</a>
-        <tr>
-           <td><a href="/jsdom/">JS201: JS and the DOM (Review)</a>
-           <td>JS201
-           <td>2-3hours
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jsdom/README.md">Meetup description</a>
-        <tr>
+       <tr>
            <td><a href="/jquery/">JS301a: jQuery Intro</a>
            <td>JS200
            <td>2-3hrs
@@ -126,11 +90,6 @@
            <td>JS301a
            <td>2-3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jquery2/README.md">Meetup description</a>
-        <tr>
-           <td><a href="/jquery-selfpaced/">JS301: jQuery (Online, Self-paced)</a>
-           <td>JS200
-           <td>2-3hrs
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jquery-selfpaced/README.md">Meetup description</a>
         <tr>
            <td><a href="/ajax/">JS302: AJAX/JSON</a>
            <td>JS201


### PR DESCRIPTION
# Summary

Teachers have been confused about which versions of the slides to use. This cleans up the index page so that it's clear which materials we will be using. 

Here's a description of changes:

* Removed links from `index.html` without removing materials

_Before you merge, make sure you visually check your changes in the deploy preview. A link to the preview will appear in the PR comments when ready._


cc @gdisf/admins
