### PR TITLE
Fix missing link + minor typo in teaching-materials/github-web/index.html

### DIFF
--- a/github-web/index.html
+++ b/github-web/index.html
@@ -516,7 +516,7 @@
 					<p>Some friendly repos for making contributions with little or no code:</p>
 					<ul>
 						<li>"Awesome Lists" are repos with lists of awesome things related to a particular topic. <a href="https://github.com/sindresorhus/awesome">This repo</a> is an awesome list of awesome lists!</li>
-						<li><a>First-Timers' Guide</a> is a repo for first timers to contribute short, single page guides on a variety of tech-realted topics.</li>
+						<li><a href="https://github.com/the-ethan-hunt/first-timers-guide">First-Timers' Guide</a> is a repo for first timers to contribute short, single page guides on a variety of tech-related topics.</li>
 					</ul>
 				</section>
 


### PR DESCRIPTION
# Summary

Fixes issue #582 

Here's a description of changes:

* Fixed First-Timers' Guide link missing href attribute to point to https://github.com/the-ethan-hunt/first-timers-guide
* Fixed typo: tech-realted -> tech-related


_Before you merge, make sure you visually check your changes in the deploy preview. A link to the preview will appear in the PR comments when ready._


cc @gdisf/admins
