### PR TITLE
Added line for whiteboarding prep class with link to slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,11 @@
            | <a href="https://github.com/gdisf/teaching-materials/blob/master/algorithms/lessonplan.md">Lesson Plan</a>
            | <a href="https://github.com/gdisf/teaching-materials/blob/master/algorithms/follow_up.md">Follow Up Email</a>
         <tr>
+           <td><a href="https://docs.google.com/presentation/d/12GqKhCHcyNhtOeV0Kex4P0-vpVsjy8GPiTpm6F1BncU/edit#slide=id.g1961f2378e_0_364/">Whiteboarding Interview Prep</a>
+           <td>None
+           <td>6hrs
+           <td>
+        <tr>
            <td><a href="/github-web">OSS101: Intro to GitHub - No terminal required!</a>
            <td>None
            <td>3hrs


### PR DESCRIPTION
# Summary

Fixes issue #616 

Not sure if there is a class description link floating around somewhere. There's no github repo for this class, which is where most of the other classes have that info.

cc @gdisf/admins
