### PR TITLE
[Issue #624] add react slides to main curriculum list

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,12 +67,10 @@
             | <a href="/bootstrap-hosting-github/bootstrap_lessonplan.html">Lesson plan</a>
             | <a href="https://github.com/gdisf/teaching-materials/blob/master/bootstrap-hosting-github/follow_up.md">Follow Up Email</a>
         <tr>
-        <tr>
            <td><a href="/javascript/">JS101: Intro to JavaScript</a>
            <td>None
            <td>10-15hrs
             <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/javascript/README.md">Meetup description</a>
-            | Lesson plan</a>
             | <a href="https://github.com/gdisf/teaching-materials/blob/master/javascript/follow_up.md">Follow Up Email</a>
         <tr>
            <td><a href="/jsweb/">JS200: JS and the Web</a>
@@ -104,6 +102,13 @@
            <td>3hrs
            <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/jasmine/README.md">Meetup description</a>
            | <a href="https://github.com/gdisf/teaching-materials/blob/master/jasmine/follow_up.md">Follow Up Email</a>
+        <tr>
+          <td><a href="/react-js/">REACT101: Intro to React.js</a>
+          <td>JS200
+          <td>12hrs
+          <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/react-js/README.md">Meetup description</a>
+          | <a href="https://docs.google.com/presentation/u/1/d/144DViot4VJSOx-jmXDLIExE06Wky6pFS4QKkHZxtl1o">Lesson plan</a>
+          | <a href="https://github.com/gdisf/teaching-materials/blob/master/react-js/follow_up.md">Follow Up Email</a>
         <tr><td><a href="/accessibility/">Web Accessibility Workshop</a>
             <td>None
             <td>3hrs
@@ -188,7 +193,7 @@
            <td><a href="/_DEPRECATED/jquery/">JS301a: jQuery Intro</a>
            <td>JS200
            <td>2-3hrs
-           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/_DEPRECATED/jquery/README.md">Meetup description</a> | Lesson plan</a> | <a href="https://github.com/gdisf/teaching-materials/blob/master/_DEPRECATED/jquery/follow_up.md">Follow Up Email</a>
+           <td> <a href="https://github.com/gdisf/teaching-materials/blob/master/_DEPRECATED/jquery/README.md">Meetup description</a> | <a href="https://github.com/gdisf/teaching-materials/blob/master/_DEPRECATED/jquery/follow_up.md">Follow Up Email</a>
         <tr>
            <td><a href="/_DEPRECATED/jquery2/">JS301b: More jQuery</a>
            <td>JS301a


### PR DESCRIPTION
# Add React course to curriculum list

Fixes issue #624 

Here's a description of changes:

* Add REACT101: Intro to React.js listing to curriculum list on main `index.html`
* Link to external slides ('Lesson Plan') as well as 'Meetup description' and 'Follow Up Email'
* Remove dead "links"

cc @gdisf/admins
