### PR TITLE
[Issue 440] Add follow-up email to deprecated GitHub desktop course

### DIFF
--- a/_DEPRECATED/github-desktop/follow_up.md
+++ b/_DEPRECATED/github-desktop/follow_up.md
@@ -1,0 +1,20 @@
+# GDI SF Post-Event Follow-Up Email
+
+Hi all,
+
+Thanks for attending the workshop, and thank you to our TAs **[TODO: ADD NAMES]** for helping out.
+
+The slides are available at: [https://www.teaching-materials.org/_deprecated/github-desktop/github#/]()
+
+We will try to always keep them available at that URL.
+
+To continue your learning, here are some recommended resources:
+* Future GDI workshops:
+	* **[TODO: ADD URLs]**
+* Online tutorials:
+	* [Learn Git Branching](https://learngitbranching.js.org/)
+* Other resources:
+	* [A Visual Git Reference](https://marklodato.github.io/visual-git-guide/index-en.html): An overview of what actually happens in each of Git command (with pictures!)
+	* [Git Cheat Sheet](https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf): A printable reference of the most useful Git commands
+
+Hope to see you at future Meetups!

--- a/index.html
+++ b/index.html
@@ -260,6 +260,8 @@
            <td>None
            <td>30mins
            <td>
+            <a href="https://github.com/gdisf/teaching-materials/blob/master/_DEPRECATED/github-desktop/follow_up.md">Follow Up Email</a>
+
     </table>
 </div>
 


### PR DESCRIPTION
# Summary

Fixes issue #440 

Here's a description of changes:

* Add follow_up.md for PROG102-ALT: Version Control with Github Desktop course
* Add link to follow-up email to site home page

_Before you merge, make sure you visually check your changes in the deploy preview. A link to the preview will appear in the PR comments when ready._


cc @gdisf/admins
