### PR TITLE
Restore Intro to Command Line link on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,13 +123,16 @@
            <td>
                <!-- <a href="https://github.com/gdisf/teaching-materials/blob/master/github-web/README.md">Meetup description</a> -->
         <tr>
+           <td><a href="/cli">PROG101: Intro to the Command Line</a>
+           <td>None
+           <td>3hrs
+           <td><a href="https://github.com/gdisf/teaching-materials/blob/master/cli/README.md">Meetup description</a>        <tr>
         <tr>
             <td><a href="/git-oss">OSS102: Command-Line Git for Open Source</a>
             <td>PROG101
             <td>3hrs
             <td>
                 <!-- <a href="https://github.com/gdisf/teaching-materials/blob/master/github-web/README.md">Meetup description</a> -->
-            <tr>
         <tr>
            <td><a href="/wordpress101/index.html">WordPress 101</a>
            <td>None


### PR DESCRIPTION
# Summary

I just noticed that when the workshop listing on the index page was split into current and deprecated workshops, the Command Line entry got dropped from the lists. 

This PR puts it back. :)